### PR TITLE
monorepo - npm workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "surfing-game",
       "version": "1.0.0",
       "license": "ISC",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@mdx-js/react": "^3.1.1",
         "@mdx-js/rollup": "^3.1.1",
@@ -1794,6 +1797,22 @@
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@surf/app": {
+      "resolved": "packages/app",
+      "link": true
+    },
+    "node_modules/@surf/core": {
+      "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/@surf/render": {
+      "resolved": "packages/render",
+      "link": true
+    },
+    "node_modules/@surf/stories": {
+      "resolved": "packages/stories",
+      "link": true
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
@@ -9723,6 +9742,33 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "packages/app": {
+      "name": "@surf/app",
+      "version": "0.0.0",
+      "dependencies": {
+        "@surf/core": "*",
+        "@surf/render": "*"
+      }
+    },
+    "packages/core": {
+      "name": "@surf/core",
+      "version": "0.0.0"
+    },
+    "packages/render": {
+      "name": "@surf/render",
+      "version": "0.0.0",
+      "dependencies": {
+        "@surf/core": "*"
+      }
+    },
+    "packages/stories": {
+      "name": "@surf/stories",
+      "version": "0.0.0",
+      "dependencies": {
+        "@surf/core": "*",
+        "@surf/render": "*"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "",
   "main": "index.js",
   "type": "module",
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "dev": "vite",
     "build": "npm run typecheck && vite build",

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @surf/app - Main game application
+ *
+ * Re-exports from src/main, src/ui, src/input, src/integration
+ */
+
+// Main entry point is src/main.tsx - this package just declares the dependency structure
+export {};

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@surf/app",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./index.ts",
+  "types": "./index.ts",
+  "dependencies": {
+    "@surf/core": "*",
+    "@surf/render": "*"
+  }
+}

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,0 +1,34 @@
+/**
+ * @surf/core - Core game state and logic
+ *
+ * This package provides barrel exports for core game logic.
+ * For conflicting names (e.g., multiple createInitialState functions),
+ * import directly from the specific module:
+ *   import { createInitialState } from '@surf/core/state/setLullModel'
+ */
+
+// Re-export all state models
+// Note: Some exports may conflict - use specific module imports if needed
+export * from '../../src/state/waveModel';
+export * from '../../src/state/energyFieldModel';
+export * from '../../src/state/foamModel';
+export * from '../../src/state/foamGridModel';
+export * from '../../src/state/backgroundWaveModel';
+export * from '../../src/state/aiPlayerModel';
+export * from '../../src/state/playerProxyModel';
+export * from '../../src/state/settingsModel';
+export * from '../../src/state/gamePersistence';
+
+// These have conflicting exports - import directly from modules if needed:
+// - src/state/bathymetryModel (amplitudeToHeight conflicts with waveModel)
+// - src/state/setLullModel (createInitialState conflicts)
+// - src/state/eventStore (createInitialState conflicts)
+
+// Core utilities
+export * from '../../src/core/math';
+
+// Update loop
+export * from '../../src/update';
+
+// General utilities
+export * from '../../src/util/fpsTracker';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@surf/core",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./index.ts",
+  "types": "./index.ts",
+  "exports": {
+    ".": "./index.ts",
+    "./*": "./*"
+  }
+}

--- a/packages/render/index.ts
+++ b/packages/render/index.ts
@@ -1,0 +1,48 @@
+/**
+ * @surf/render - Rendering utilities for canvas
+ *
+ * Re-exports from src/render
+ */
+
+// Bathymetry rendering
+export {
+  buildBathymetryCache,
+  depthToColor,
+  createBathymetryCacheManager,
+} from '../../src/render/bathymetryRenderer';
+
+// Wave rendering
+export { WAVE_COLORS, getWaveColors, renderWave, renderWaves } from '../../src/render/waveRenderer';
+
+// Energy field rendering
+export { renderEnergyField } from '../../src/render/energyFieldRenderer';
+
+// Foam rendering (marching squares)
+export {
+  buildIntensityGrid,
+  buildIntensityGridOptionA,
+  boxBlur,
+  extractLineSegments,
+  renderMultiContour,
+  renderMultiContourOptionA,
+  renderMultiContourOptionB,
+  renderMultiContourOptionC,
+  renderMultiContourFromGrid,
+  renderMultiContourOptionAFromGrid,
+  renderMultiContourOptionBFromGrid,
+  renderMultiContourOptionCFromGrid,
+} from '../../src/render/marchingSquares';
+
+// Coordinate utilities
+export {
+  progressToScreenY,
+  screenYToProgress,
+  getOceanBounds,
+  calculateTravelDuration,
+} from '../../src/render/coordinates';
+
+// Color scales
+export * from '../../src/render/colorScales';
+
+// Foam config
+export * from '../../src/render/foamConfig';

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@surf/render",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./index.ts",
+  "types": "./index.ts",
+  "exports": {
+    ".": "./index.ts",
+    "./*": "./*"
+  },
+  "dependencies": {
+    "@surf/core": "*"
+  }
+}

--- a/packages/stories/index.ts
+++ b/packages/stories/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @surf/stories - Storybook components and visual tests
+ *
+ * Re-exports from stories/
+ */
+
+// Stories entry point is stories/main.tsx - this package just declares the dependency structure
+export {};

--- a/packages/stories/package.json
+++ b/packages/stories/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@surf/stories",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./index.ts",
+  "types": "./index.ts",
+  "dependencies": {
+    "@surf/core": "*",
+    "@surf/render": "*"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,9 +18,17 @@
     "baseUrl": ".",
     "paths": {
       "@src/*": ["src/*"],
-      "@stories/*": ["stories/*"]
+      "@stories/*": ["stories/*"],
+      "@surf/core": ["packages/core/index.ts"],
+      "@surf/core/*": ["packages/core/*"],
+      "@surf/render": ["packages/render/index.ts"],
+      "@surf/render/*": ["packages/render/*"],
+      "@surf/app": ["packages/app/index.ts"],
+      "@surf/app/*": ["packages/app/*"],
+      "@surf/stories": ["packages/stories/index.ts"],
+      "@surf/stories/*": ["packages/stories/*"]
     }
   },
-  "include": ["src/**/*", "stories/**/*", "tests/**/*"],
+  "include": ["src/**/*", "stories/**/*", "tests/**/*", "packages/**/*"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- Add npm workspaces configuration to enable monorepo package management
- Create initial package structure with `packages/app`, `packages/core`, `packages/render`, and `packages/stories`
- Each package has its own `package.json` with appropriate dependencies and TypeScript entry point
- Update root `tsconfig.json` with project references for the new packages

## Test plan
- [ ] Run `npm install` from root to verify workspace resolution
- [ ] Verify packages can import from each other via workspace references
- [ ] Run existing tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)