### PR TITLE
test: rendering-only visual bug to verify CI detection

### DIFF
--- a/src/render/energyFieldRenderer.ts
+++ b/src/render/energyFieldRenderer.ts
@@ -70,9 +70,10 @@ export function renderEnergyFieldFast(ctx, field, oceanTop, oceanBottom, canvasW
   const data = imageData.data;
 
   // Color mapping parameters
+  // BUG: Intentionally swapped peak/trough colors to test visual regression detection
   const baseColor = { r: 26, g: 74, b: 110 };
-  const peakColor = { r: 74, g: 144, b: 184 };
-  const troughColor = { r: 13, g: 58, b: 92 };
+  const peakColor = { r: 13, g: 58, b: 92 }; // Swapped: was troughColor
+  const troughColor = { r: 74, g: 144, b: 184 }; // Swapped: was peakColor
 
   // Fill each pixel
   for (let py = 0; py < pixelHeight; py++) {


### PR DESCRIPTION
## Summary
- Swaps peak/trough colors in `energyFieldRenderer.ts` to test visual regression detection
- This is a **rendering-only bug** that doesn't break any unit tests
- Demonstrates the value of visual regression testing for catching rendering bugs that slip through the unit test layer

## What This Tests
Unlike the first PR (`test/invert-viridis-colormap`) which had to skip unit tests, this PR:
- ✅ All unit tests pass (567/567)
- ✅ All smoke tests pass (5/5)
- ❌ Visual regression should **fail** in CI

This proves that visual regression testing catches bugs that unit tests miss.

## Test Plan
- [ ] Wait for CI to run
- [ ] Verify unit tests pass
- [ ] Verify visual regression tests **fail** (detecting the color swap)
- [ ] Close this PR after verification (do not merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)